### PR TITLE
Fix emit return

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is very easy to listen for this event and handle it
 However, we want to intercept that event and modify the data. We can do that by setting an `interceptor` with `intercept(event, interceptor)`. It is passed all arguments that would be passed to the emitter, as well as a standard node callback. In this case, let's just add a prefix on to the data.
 
 	emitter.intercept('data', function(arg, done) {
-		done(null, 'intercepted ' + arg);
+		return done(null, 'intercepted ' + arg);
 	});
 
 This code will be executed before the handler, and the new argument will be passed on to the handler appropriately.
@@ -46,7 +46,7 @@ Here's that sample code all together. Of course, `intercept` supports proper fun
 	.on('data', function(arg) {
 		console.log(arg); 
 	}).intercept('data', function(arg, done) {
-		done(null, 'intercepted ' + arg);
+		return done(null, 'intercepted ' + arg);
 	}).emit('data', 'myData');
 	//logs 'intercepted myData'
 
@@ -60,7 +60,7 @@ There may be times when you want to intercept one event and call another. Luckil
 		this
 		.emit('otherData')
 		.emit('thirdData');
-		done(null);
+		return done(null);
 	});
 	//emits 'data', 'otherData', and 'thirdData'
 
@@ -103,8 +103,8 @@ Of course, many EventEmitters that you have the pleasure of using will not have 
 	.on('data', function(arg) {
 		console.log(arg); 
 	}).intercept('data', function(arg, done) {
-		done(null, 'intercepted ' + arg);
-	}) .emit('data', 'myData');
+		return done(null, 'intercepted ' + arg);
+	}).emit('data', 'myData');
 	//logs 'intercepted myData'
 
 Now, you should be able to call `intercept` on the standard `EventEmitter`.

--- a/lib/events-intercept.js
+++ b/lib/events-intercept.js
@@ -50,11 +50,11 @@
         if (err) {
           _this.emit('error', err);
         } else if (completed === interceptor.length) {
-          superCall.apply(_this, [type].concat(Array.prototype.slice.call(arguments).slice(1)));
+          return superCall.apply(_this, [type].concat(Array.prototype.slice.call(arguments).slice(1)));
         } else {
           trueArgs = Array.prototype.slice.call(arguments).slice(1).concat([next]);
           completed += 1;
-          interceptor[completed - 1].apply(_this, trueArgs);
+          return interceptor[completed - 1].apply(_this, trueArgs);
         }
       }
 
@@ -67,12 +67,12 @@
       if (!interceptor) {
 
         //Just pass through
-        superCall.apply(_this, arguments);
+        return superCall.apply(_this, arguments);
 
       } else {
 
         completed = 0;
-        next.apply(_this, [null].concat(Array.prototype.slice.call(arguments).slice(1)));
+        return next.apply(_this, [null].concat(Array.prototype.slice.call(arguments).slice(1)));
 
       }
     };

--- a/test/emit_return.js
+++ b/test/emit_return.js
@@ -1,0 +1,87 @@
+var chai = require('chai'),
+  assert = chai.assert.equal,
+	eventsIntercept = require('../lib/events-intercept'),
+	events = require('events');
+
+describe('patched event emitters', function () {
+  describe('with no intercepts', function () {
+    it('returns true if an event had handlers', function () {
+      var ee = new events.EventEmitter();
+      eventsIntercept.patch(ee);
+
+      ee.on('foo', function () {});
+
+      assert(ee.emit('foo'), true, "emit('foo') is true");
+    });
+
+    it('returns false if an event had no handlers', function () {
+      var ee = new events.EventEmitter();
+      eventsIntercept.patch(ee);
+      ee.on('foo', function () {});
+
+      assert(ee.emit('bar'), false, "emit('bar') is false");
+    });
+  });
+
+  describe('with the event intercepted', function () {
+    it('returns true if an event had handlers', function () {
+      var ee = new events.EventEmitter();
+      eventsIntercept.patch(ee);
+      
+      var intercepted = false;
+      var handled = false;
+      
+      ee.on('foo', function () { handled = true; });
+      ee.intercept('foo', function (next) { intercepted = true; return next(); });
+
+      assert(ee.emit('foo'), true, "emit('foo') returns true");
+      assert(intercepted, true, "interceptor was invoked");
+      assert(handled, true, "handler was invoked");
+    });
+
+    it('returns false if an event had no handlers', function () {
+      var ee = new events.EventEmitter();
+      eventsIntercept.patch(ee);
+
+      var intercepted = false;
+      
+      ee.intercept('bar', function (next) { intercepted = true; return next(); });
+
+      assert(ee.emit('bar'), false, "emit('bar') returns false");
+      assert(intercepted, true, "interceptor was called");
+    });
+  });
+});
+
+describe('events-intercept event emitters', function () {
+  it('returns true if an event had handlers', function () {
+    var ee = new eventsIntercept.EventEmitter();
+    ee.on('foo', function () {});
+
+    assert(ee.emit('foo'), true, "emit('foo') is true");
+  });
+
+  it('returns false if an event had no handlers', function () {
+    var ee = new eventsIntercept.EventEmitter();
+    eventsIntercept.patch(ee);
+    ee.on('foo', function () {});
+
+    assert(ee.emit('bar'), false, "emit('bar') is false");
+  });
+
+  describe('with the event intercepted', function () {
+    it('returns true if an event had handlers', function () {
+      var ee = new eventsIntercept.EventEmitter();
+      
+      var intercepted = false;
+      var handled = false;
+      
+      ee.on('foo', function () { handled = true; });
+      ee.intercept('foo', function (next) { intercepted = true; return next(); });
+
+      assert(ee.emit('foo'), true, "emit('foo') returns true");
+      assert(intercepted, true, "interceptor was invoked");
+      assert(handled, true, "handler was invoked");
+    });
+  });
+});


### PR DESCRIPTION
Addresses #1.

In order to make sure the return value of the original `emit` function is preserved, I added some return statements into the `emitFactory` function. This also requires returning the value of the `next` or `done` function inside interceptors, so I added that to the `README.md`. Also added tests.

If you don't want to put returns in front of those calls to `done` in the `README.md` I can remove that commit from the branch, but I think it's probably a good idea. It is also possible to forge the return of `emit` rather than trying to propagate its value thru the callback chain; this is a little janky but would produce a bit of a cleaner interface. If you want I can write something like that, up to you.
